### PR TITLE
Reduce base library requirement to 4.6

### DIFF
--- a/pure-zlib.cabal
+++ b/pure-zlib.cabal
@@ -18,8 +18,9 @@ library
   ghc-options:        -Wall
   hs-source-dirs:     src
   build-depends:
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       bytestring                 >= 0.10  && < 0.11,
+                      bytestring-builder         >= 0.10  && < 0.11,
                       containers                 >= 0.5   && < 0.7,
                       fingertree                 >= 0.1   && < 0.3,
                       monadLib                   >= 3.7   && < 3.9
@@ -40,7 +41,7 @@ executable deflate
   main-is:            Deflate.hs
   ghc-options:        -Wall
   build-depends:
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       bytestring                 >= 0.10  && < 0.11,
                       pure-zlib                  >= 0.3   && < 0.5
 
@@ -52,7 +53,7 @@ test-suite test-zlib
   default-language:   Haskell2010
   ghc-options:        -fno-warn-orphans
   build-depends:
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       bytestring                 >= 0.10  && < 0.11,
                       pure-zlib                  >= 0.3   && < 1.1,
                       HUnit                      >= 1.2   && < 1.4,


### PR DESCRIPTION
pure-zlib works fine with ghc 7.6.3 and base 4.6. Only `MultiwayIf` is not supported, but also not needed.