### PR TITLE
Tighten base-bound to fix broken build with newer base-compat versions

### DIFF
--- a/pure-zlib.cabal
+++ b/pure-zlib.cabal
@@ -22,7 +22,7 @@ library
   build-depends:
                       array              >= 0.4   && < 0.9,
                       base               >= 4.6   && < 5.0,
-                      base-compat        >= 0.9.1 && < 0.11,
+                      base-compat        >= 0.9.1 && < 0.10,
                       bytestring         >= 0.10  && < 0.11,
                       bytestring-builder >= 0.10  && < 0.11,
                       containers         >= 0.5   && < 0.7,


### PR DESCRIPTION
As a hackage trustee, I've made this change as a metadata revision to 0.6, 0.6.1, 0.6.2. I've also tightened the base bound on all versions except 0.6.2 since they were giving bad build plans for ghc 8.4

This PR on the version bound will fix the build, or you could change the code to be compatible with base-compat 0.10.1 and keep the bound as-is.