### PR TITLE
Improve the performance of the library

### DIFF
--- a/pure-zlib.cabal
+++ b/pure-zlib.cabal
@@ -25,8 +25,7 @@ library
                       base-compat        >= 0.9.1 && < 0.12,
                       bytestring         >= 0.10  && < 0.11,
                       bytestring-builder >= 0.10  && < 0.11,
-                      containers         >= 0.5   && < 0.7,
-                      fingertree         >= 0.1   && < 0.3
+                      containers         >= 0.5   && < 0.7
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*
   exposed-modules:
@@ -36,6 +35,8 @@ library
                       Codec.Compression.Zlib.HuffmanTree,
                       Codec.Compression.Zlib.Monad,
                       Codec.Compression.Zlib.OutputWindow
+  other-modules:
+                      Codec.Compression.Zlib.FingerTree
   default-extensions:
                       BangPatterns,
                       DeriveDataTypeable,

--- a/src/Codec/Compression/Zlib/Adler32.hs
+++ b/src/Codec/Compression/Zlib/Adler32.hs
@@ -1,30 +1,56 @@
+{-# LANGUAGE MagicHash #-}
 module Codec.Compression.Zlib.Adler32(
          AdlerState
        , initialAdlerState
        , advanceAdler
+       , advanceAdlerBlock
        , finalizeAdler
        )
  where
 
 import Data.Bits(shiftL, (.|.))
-import Data.Word(Word8, Word32)
+import qualified Data.ByteString.Lazy as L
+import GHC.Exts ( Word#, plusWord#, remWord# )
+import GHC.Word ( Word8(..), Word32(..) )
 
-data AdlerState = AdlerState { adlerA :: !Word32, adlerB :: !Word32 }
+data AdlerState = AdlerState { _adlerA :: Word#, _adlerB :: Word# }
 
 initialAdlerState :: AdlerState
-initialAdlerState = AdlerState 1 0
-
-adlerAdd :: Word32 -> Word32 -> Word32
-adlerAdd x y = (x + y) `mod` 65521
-{-# INLINE adlerAdd #-}
+initialAdlerState = AdlerState 1## 0##
 
 advanceAdler :: AdlerState -> Word8 -> AdlerState
-advanceAdler state b = AdlerState a' b'
+advanceAdler (AdlerState a b) (W8# v) = AdlerState a' b'
  where
-  a' = adlerAdd (adlerA state) (fromIntegral b)
-  b' = adlerAdd (adlerB state) a'
+  a' = (a `plusWord#` v) `remWord#` 65521##
+  b' = (b `plusWord#` a') `remWord#` 65521##
+{-# INLINE advanceAdler #-}
+
+advanceNoMod :: AdlerState -> Word8 -> AdlerState
+advanceNoMod (AdlerState a b) (W8# v) = AdlerState a' b'
+ where
+  a' = a `plusWord#` v
+  b' = b `plusWord#` a'
+{-# INLINE advanceNoMod #-}
+
+-- The block must be less than 5552 bytes long in this case
+advanceAdlerLimited :: AdlerState -> L.ByteString -> AdlerState
+advanceAdlerLimited !state !bl = AdlerState stateA' stateB'
+ where
+  !(AdlerState stateA stateB) = L.foldl' advanceNoMod state bl
+  stateA' = stateA `remWord#` 65521##
+  stateB' = stateB `remWord#` 65521##
+
+advanceAdlerBlock :: AdlerState -> L.ByteString -> AdlerState
+advanceAdlerBlock !state !bl
+  | L.length bl == 0 = state
+  | L.length bl == 1 = advanceAdler state (L.head bl)
+  | L.length bl < 5552 = advanceAdlerLimited state bl 
+  | otherwise = advanceAdlerBlock (advanceAdlerBlock state first5551) rest
+ where
+  (!first5551, !rest) = L.splitAt 5551 bl
 
 finalizeAdler :: AdlerState -> Word32
-finalizeAdler state = ((adlerB state) `shiftL` 16) .|.  adlerA state
-
-
+finalizeAdler (AdlerState a b) = high .|. low
+  where
+   high = (W32# b) `shiftL` 16
+   low = W32# a

--- a/src/Codec/Compression/Zlib/Adler32.hs
+++ b/src/Codec/Compression/Zlib/Adler32.hs
@@ -7,28 +7,24 @@ module Codec.Compression.Zlib.Adler32(
  where
 
 import Data.Bits(shiftL, (.|.))
-import Data.Word(Word8, Word16, Word32)
+import Data.Word(Word8, Word32)
 
-data AdlerState = AdlerState { adlerA :: !Word16, adlerB :: !Word16 }
+data AdlerState = AdlerState { adlerA :: !Word32, adlerB :: !Word32 }
 
 initialAdlerState :: AdlerState
 initialAdlerState = AdlerState 1 0
 
-adlerAdd :: (Integral a, Integral b) => a -> b -> Word16
-adlerAdd x y = fromIntegral ((x32 + y32) `mod` 65521)
- where
-  x32, y32 :: Word32
-  x32 = fromIntegral x
-  y32 = fromIntegral y
+adlerAdd :: Word32 -> Word32 -> Word32
+adlerAdd x y = (x + y) `mod` 65521
+{-# INLINE adlerAdd #-}
 
 advanceAdler :: AdlerState -> Word8 -> AdlerState
 advanceAdler state b = AdlerState a' b'
  where
-  a' = adlerAdd (adlerA state) b
+  a' = adlerAdd (adlerA state) (fromIntegral b)
   b' = adlerAdd (adlerB state) a'
 
 finalizeAdler :: AdlerState -> Word32
-finalizeAdler state = ((fromIntegral (adlerB state)) `shiftL` 16)
-                   .|.  fromIntegral (adlerA state)
+finalizeAdler state = ((adlerB state) `shiftL` 16) .|.  adlerA state
 
 

--- a/src/Codec/Compression/Zlib/FingerTree.hs
+++ b/src/Codec/Compression/Zlib/FingerTree.hs
@@ -1,0 +1,647 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.FingerTree
+-- Copyright   :  (c) Ross Paterson, Ralf Hinze 2006
+-- License     :  BSD-style
+-- Maintainer  :  R.Paterson@city.ac.uk
+-- Stability   :  experimental
+-- Portability :  non-portable (MPTCs and functional dependencies)
+--
+-- A general sequence representation with arbitrary annotations, for
+-- use as a base for implementations of various collection types, as
+-- described in section 4 of
+--
+--  * Ralf Hinze and Ross Paterson,
+--    \"Finger trees: a simple general-purpose data structure\",
+--    /Journal of Functional Programming/ 16:2 (2006) pp 197-217.
+--    <http://staff.city.ac.uk/~ross/papers/FingerTree.html>
+--
+-- For a directly usable sequence type, see @Data.Sequence@, which is
+-- a specialization of this structure.
+--
+-- An amortized running time is given for each operation, with /n/
+-- referring to the length of the sequence.  These bounds hold even in
+-- a persistent (shared) setting.
+--
+-- /Note/: Many of these operations have the same names as similar
+-- operations on lists in the "Prelude".  The ambiguity may be resolved
+-- using either qualification or the @hiding@ clause.
+--
+-----------------------------------------------------------------------------
+
+module Codec.Compression.Zlib.FingerTree (
+    FingerTree,
+    Measured(..),
+    -- * Construction
+    empty,
+    (|>),
+    -- ** Examining the ends
+    ViewL(..), viewl,
+    -- ** Splitting
+    -- | These functions are special cases of 'search'.
+    split,
+    -- * Example
+    -- $example
+    toBuilder
+    ) where
+
+import Prelude hiding (null, reverse)
+import GHC.Generics
+import qualified Data.ByteString as S
+import Data.ByteString.Builder(Builder, byteString)
+
+type Measure = Int
+
+infixr 5 ><
+infixr 5 <|, :<
+infixl 5 |>, :>
+
+-- | View of the left end of a sequence.
+data ViewL s a
+    = EmptyL        -- ^ empty sequence
+    | a :< s a      -- ^ leftmost element and the rest of the sequence
+    deriving (Eq, Ord, Show, Read, Generic)
+
+-- | View of the right end of a sequence.
+data ViewR s a
+    = EmptyR        -- ^ empty sequence
+    | s a :> a      -- ^ the sequence minus the rightmost element,
+                    -- and the rightmost element
+    deriving (Eq, Ord, Show, Read, Generic)
+
+instance (Functor s) => Functor (ViewL s) where
+    fmap _ EmptyL    = EmptyL
+    fmap f (x :< xs) = f x :< fmap f xs
+
+instance (Functor s) => Functor (ViewR s) where
+    fmap _ EmptyR    = EmptyR
+    fmap f (xs :> x) = fmap f xs :> f x
+
+instance (Measured a) => Semigroup (FingerTree a) where
+    (<>) = (><)
+
+-- | 'empty' and '><'.
+instance (Measured a) => Monoid (FingerTree a) where
+    mempty = empty
+    mappend = (><)
+
+-- Explicit Digit type (Exercise 1)
+
+data Digit a
+    = One a
+    | Two a a
+    | Three a a a
+    | Four a a a a
+    deriving (Show)
+
+-------------------
+-- 4.1 Measurements
+-------------------
+
+-- | Things that can be measured.
+class Measured a where
+    measure :: a -> Measure
+
+instance (Measured a) => Measured (Digit a) where
+    measure (One a1) = measure a1
+    measure (Two a1 a2) = measure a1 + measure a2
+    measure (Three a1 a2 a3) = measure a1 + measure a2 + measure a3
+    measure (Four a1 a2 a3 a4) = measure a1 + measure a2 + measure a3 + measure a4
+
+---------------------------
+-- 4.2 Caching measurements
+---------------------------
+
+data Node a = Node2 !Measure a a | Node3 !Measure a a a
+    deriving (Show)
+
+node2        ::  (Measured a) => a -> a -> Node a
+node2 a b    =   Node2 (measure a + measure b) a b
+
+node3        ::  (Measured a) => a -> a -> a -> Node a
+node3 a b c  =   Node3 (measure a + measure b + measure c) a b c
+
+instance Measured (Node a) where
+    measure (Node2 v _ _)    =  v
+    measure (Node3 v _ _ _)  =  v
+
+nodeToDigit :: Node a -> Digit a
+nodeToDigit (Node2 _ a b) = Two a b
+nodeToDigit (Node3 _ a b c) = Three a b c
+
+-- | A representation of a sequence of values of type @a@, allowing
+-- access to the ends in constant time, and append and split in time
+-- logarithmic in the size of the smaller piece.
+--
+-- The collection is also parameterized by a measure type @v@, which
+-- is used to specify a position in the sequence for the 'split' operation.
+-- The types of the operations enforce the constraint @'Measured' v a@,
+-- which also implies that the type @v@ is determined by @a@.
+--
+-- A variety of abstract data types can be implemented by using different
+-- element types and measurements.
+data FingerTree a
+    = Empty
+    | Single a
+    | Deep !Measure !(Digit a) (FingerTree (Node a)) !(Digit a)
+    deriving (Show)
+
+deep ::  (Measured a) => Digit a -> FingerTree (Node a) -> Digit a -> FingerTree a
+deep pr m sf =
+    Deep ((measure pr + measure m) + measure sf) pr m sf
+
+-- | /O(1)/. The cached measure of a tree.
+instance (Measured a) => Measured (FingerTree a) where
+    measure Empty           =  0
+    measure (Single x)      =  measure x
+    measure (Deep v _ _ _)  =  v
+
+-----------------------------------------------------
+-- 4.3 Construction, deconstruction and concatenation
+-----------------------------------------------------
+
+-- | /O(1)/. The empty sequence.
+empty :: Measured a => FingerTree a
+empty = Empty
+
+-- | /O(1)/. Add an element to the left end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(<|) :: (Measured a) => a -> FingerTree a -> FingerTree a
+a <| Empty              =  Single a
+a <| Single b           =  deep (One a) Empty (One b)
+a <| Deep v (Four b c d e) m sf = m `seq`
+    Deep (measure a + v) (Two a b) (node3 c d e <| m) sf
+a <| Deep v pr m sf     =
+    Deep (measure a + v) (consDigit a pr) m sf
+
+consDigit :: a -> Digit a -> Digit a
+consDigit a (One b) = Two a b
+consDigit a (Two b c) = Three a b c
+consDigit a (Three b c d) = Four a b c d
+consDigit _ (Four _ _ _ _) = illegal_argument "consDigit"
+
+-- | /O(1)/. Add an element to the right end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(|>) :: (Measured a) => FingerTree a -> a -> FingerTree a
+Empty |> a              =  Single a
+Single a |> b           =  deep (One a) Empty (One b)
+Deep v pr m (Four a b c d) |> e = m `seq`
+    Deep (v + measure e) pr (m |> node3 a b c) (Two d e)
+Deep v pr m sf |> x     =
+    Deep (v + measure x) pr m (snocDigit sf x)
+
+snocDigit :: Digit a -> a -> Digit a
+snocDigit (One a) b = Two a b
+snocDigit (Two a b) c = Three a b c
+snocDigit (Three a b c) d = Four a b c d
+snocDigit (Four _ _ _ _) _ = illegal_argument "snocDigit"
+
+-- | /O(1)/. Analyse the left end of a sequence.
+viewl :: (Measured a) => FingerTree a -> ViewL FingerTree a
+viewl Empty                     =  EmptyL
+viewl (Single x)                =  x :< Empty
+viewl (Deep _ (One x) m sf)     =  x :< rotL m sf
+viewl (Deep _ pr m sf)          =  lheadDigit pr :< deep (ltailDigit pr) m sf
+
+rotL :: (Measured a) => FingerTree (Node a) -> Digit a -> FingerTree a
+rotL m sf      =   case viewl m of
+    EmptyL  ->  digitToTree sf
+    a :< m' ->  Deep (measure m + measure sf) (nodeToDigit a) m' sf
+
+lheadDigit :: Digit a -> a
+lheadDigit (One a) = a
+lheadDigit (Two a _) = a
+lheadDigit (Three a _ _) = a
+lheadDigit (Four a _ _ _) = a
+
+ltailDigit :: Digit a -> Digit a
+ltailDigit (One _) = illegal_argument "ltailDigit"
+ltailDigit (Two _ b) = One b
+ltailDigit (Three _ b c) = Two b c
+ltailDigit (Four _ b c d) = Three b c d
+
+-- | /O(1)/. Analyse the right end of a sequence.
+viewr :: (Measured a) => FingerTree a -> ViewR FingerTree a
+viewr Empty                     =  EmptyR
+viewr (Single x)                =  Empty :> x
+viewr (Deep _ pr m (One x))     =  rotR pr m :> x
+viewr (Deep _ pr m sf)          =  deep pr m (rtailDigit sf) :> rheadDigit sf
+
+rotR :: (Measured a) => Digit a -> FingerTree (Node a) -> FingerTree a
+rotR pr m = case viewr m of
+    EmptyR  ->  digitToTree pr
+    m' :> a ->  Deep (measure pr + measure m) pr m' (nodeToDigit a)
+
+rheadDigit :: Digit a -> a
+rheadDigit (One a) = a
+rheadDigit (Two _ b) = b
+rheadDigit (Three _ _ c) = c
+rheadDigit (Four _ _ _ d) = d
+
+rtailDigit :: Digit a -> Digit a
+rtailDigit (One _) = illegal_argument "rtailDigit"
+rtailDigit (Two a _) = One a
+rtailDigit (Three a b _) = Two a b
+rtailDigit (Four a b c _) = Three a b c
+
+digitToTree :: (Measured a) => Digit a -> FingerTree a
+digitToTree (One a) = Single a
+digitToTree (Two a b) = deep (One a) Empty (One b)
+digitToTree (Three a b c) = deep (Two a b) Empty (One c)
+digitToTree (Four a b c d) = deep (Two a b) Empty (Two c d)
+
+----------------
+-- Concatenation
+----------------
+
+-- | /O(log(min(n1,n2)))/. Concatenate two sequences.
+(><) :: (Measured a) => FingerTree a -> FingerTree a -> FingerTree a
+(><) =  appendTree0
+
+appendTree0 :: (Measured a) => FingerTree a -> FingerTree a -> FingerTree a
+appendTree0 Empty xs =
+    xs
+appendTree0 xs Empty =
+    xs
+appendTree0 (Single x) xs =
+    x <| xs
+appendTree0 xs (Single x) =
+    xs |> x
+appendTree0 (Deep _ pr1 m1 sf1) (Deep _ pr2 m2 sf2) =
+    deep pr1 (addDigits0 m1 sf1 pr2 m2) sf2
+
+addDigits0 :: (Measured a) => FingerTree (Node a) -> Digit a -> Digit a -> FingerTree (Node a) -> FingerTree (Node a)
+addDigits0 m1 (One a) (One b) m2 =
+    appendTree1 m1 (node2 a b) m2
+addDigits0 m1 (One a) (Two b c) m2 =
+    appendTree1 m1 (node3 a b c) m2
+addDigits0 m1 (One a) (Three b c d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits0 m1 (One a) (Four b c d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits0 m1 (Two a b) (One c) m2 =
+    appendTree1 m1 (node3 a b c) m2
+addDigits0 m1 (Two a b) (Two c d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits0 m1 (Two a b) (Three c d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits0 m1 (Two a b) (Four c d e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits0 m1 (Three a b c) (One d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits0 m1 (Three a b c) (Two d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits0 m1 (Three a b c) (Three d e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits0 m1 (Three a b c) (Four d e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits0 m1 (Four a b c d) (One e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits0 m1 (Four a b c d) (Two e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits0 m1 (Four a b c d) (Three e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits0 m1 (Four a b c d) (Four e f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+
+appendTree1 :: (Measured a) => FingerTree a -> a -> FingerTree a -> FingerTree a
+appendTree1 Empty a xs =
+    a <| xs
+appendTree1 xs a Empty =
+    xs |> a
+appendTree1 (Single x) a xs =
+    x <| a <| xs
+appendTree1 xs a (Single x) =
+    xs |> a |> x
+appendTree1 (Deep _ pr1 m1 sf1) a (Deep _ pr2 m2 sf2) =
+    deep pr1 (addDigits1 m1 sf1 a pr2 m2) sf2
+
+addDigits1 :: (Measured a) => FingerTree (Node a) -> Digit a -> a -> Digit a -> FingerTree (Node a) -> FingerTree (Node a)
+addDigits1 m1 (One a) b (One c) m2 =
+    appendTree1 m1 (node3 a b c) m2
+addDigits1 m1 (One a) b (Two c d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits1 m1 (One a) b (Three c d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits1 m1 (One a) b (Four c d e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits1 m1 (Two a b) c (One d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits1 m1 (Two a b) c (Two d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits1 m1 (Two a b) c (Three d e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits1 m1 (Two a b) c (Four d e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits1 m1 (Three a b c) d (One e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits1 m1 (Three a b c) d (Two e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits1 m1 (Three a b c) d (Three e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits1 m1 (Three a b c) d (Four e f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits1 m1 (Four a b c d) e (One f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits1 m1 (Four a b c d) e (Two f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits1 m1 (Four a b c d) e (Three f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits1 m1 (Four a b c d) e (Four f g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+
+appendTree2 :: (Measured a) => FingerTree a -> a -> a -> FingerTree a -> FingerTree a
+appendTree2 Empty a b xs =
+    a <| b <| xs
+appendTree2 xs a b Empty =
+    xs |> a |> b
+appendTree2 (Single x) a b xs =
+    x <| a <| b <| xs
+appendTree2 xs a b (Single x) =
+    xs |> a |> b |> x
+appendTree2 (Deep _ pr1 m1 sf1) a b (Deep _ pr2 m2 sf2) =
+    deep pr1 (addDigits2 m1 sf1 a b pr2 m2) sf2
+
+addDigits2 :: (Measured a) => FingerTree (Node a) -> Digit a -> a -> a -> Digit a -> FingerTree (Node a) -> FingerTree (Node a)
+addDigits2 m1 (One a) b c (One d) m2 =
+    appendTree2 m1 (node2 a b) (node2 c d) m2
+addDigits2 m1 (One a) b c (Two d e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits2 m1 (One a) b c (Three d e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits2 m1 (One a) b c (Four d e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits2 m1 (Two a b) c d (One e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits2 m1 (Two a b) c d (Two e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits2 m1 (Two a b) c d (Three e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits2 m1 (Two a b) c d (Four e f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits2 m1 (Three a b c) d e (One f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits2 m1 (Three a b c) d e (Two f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits2 m1 (Three a b c) d e (Three f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits2 m1 (Three a b c) d e (Four f g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits2 m1 (Four a b c d) e f (One g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits2 m1 (Four a b c d) e f (Two g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits2 m1 (Four a b c d) e f (Three g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits2 m1 (Four a b c d) e f (Four g h i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+
+appendTree3 :: (Measured a) => FingerTree a -> a -> a -> a -> FingerTree a -> FingerTree a
+appendTree3 Empty a b c xs =
+    a <| b <| c <| xs
+appendTree3 xs a b c Empty =
+    xs |> a |> b |> c
+appendTree3 (Single x) a b c xs =
+    x <| a <| b <| c <| xs
+appendTree3 xs a b c (Single x) =
+    xs |> a |> b |> c |> x
+appendTree3 (Deep _ pr1 m1 sf1) a b c (Deep _ pr2 m2 sf2) =
+    deep pr1 (addDigits3 m1 sf1 a b c pr2 m2) sf2
+
+addDigits3 :: (Measured a) => FingerTree (Node a) -> Digit a -> a -> a -> a -> Digit a -> FingerTree (Node a) -> FingerTree (Node a)
+addDigits3 m1 (One a) b c d (One e) m2 =
+    appendTree2 m1 (node3 a b c) (node2 d e) m2
+addDigits3 m1 (One a) b c d (Two e f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits3 m1 (One a) b c d (Three e f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits3 m1 (One a) b c d (Four e f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits3 m1 (Two a b) c d e (One f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits3 m1 (Two a b) c d e (Two f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits3 m1 (Two a b) c d e (Three f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits3 m1 (Two a b) c d e (Four f g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits3 m1 (Three a b c) d e f (One g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits3 m1 (Three a b c) d e f (Two g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits3 m1 (Three a b c) d e f (Three g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits3 m1 (Three a b c) d e f (Four g h i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+addDigits3 m1 (Four a b c d) e f g (One h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits3 m1 (Four a b c d) e f g (Two h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits3 m1 (Four a b c d) e f g (Three h i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+addDigits3 m1 (Four a b c d) e f g (Four h i j k) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node3 g h i) (node2 j k) m2
+
+appendTree4 :: (Measured a) => FingerTree a -> a -> a -> a -> a -> FingerTree a -> FingerTree a
+appendTree4 Empty a b c d xs =
+    a <| b <| c <| d <| xs
+appendTree4 xs a b c d Empty =
+    xs |> a |> b |> c |> d
+appendTree4 (Single x) a b c d xs =
+    x <| a <| b <| c <| d <| xs
+appendTree4 xs a b c d (Single x) =
+    xs |> a |> b |> c |> d |> x
+appendTree4 (Deep _ pr1 m1 sf1) a b c d (Deep _ pr2 m2 sf2) =
+    deep pr1 (addDigits4 m1 sf1 a b c d pr2 m2) sf2
+
+addDigits4 :: (Measured a) => FingerTree (Node a) -> Digit a -> a -> a -> a -> a -> Digit a -> FingerTree (Node a) -> FingerTree (Node a)
+addDigits4 m1 (One a) b c d e (One f) m2 =
+    appendTree2 m1 (node3 a b c) (node3 d e f) m2
+addDigits4 m1 (One a) b c d e (Two f g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits4 m1 (One a) b c d e (Three f g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits4 m1 (One a) b c d e (Four f g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits4 m1 (Two a b) c d e f (One g) m2 =
+    appendTree3 m1 (node3 a b c) (node2 d e) (node2 f g) m2
+addDigits4 m1 (Two a b) c d e f (Two g h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits4 m1 (Two a b) c d e f (Three g h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits4 m1 (Two a b) c d e f (Four g h i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+addDigits4 m1 (Three a b c) d e f g (One h) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node2 g h) m2
+addDigits4 m1 (Three a b c) d e f g (Two h i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits4 m1 (Three a b c) d e f g (Three h i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+addDigits4 m1 (Three a b c) d e f g (Four h i j k) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node3 g h i) (node2 j k) m2
+addDigits4 m1 (Four a b c d) e f g h (One i) m2 =
+    appendTree3 m1 (node3 a b c) (node3 d e f) (node3 g h i) m2
+addDigits4 m1 (Four a b c d) e f g h (Two i j) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node2 g h) (node2 i j) m2
+addDigits4 m1 (Four a b c d) e f g h (Three i j k) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node3 g h i) (node2 j k) m2
+addDigits4 m1 (Four a b c d) e f g h (Four i j k l) m2 =
+    appendTree4 m1 (node3 a b c) (node3 d e f) (node3 g h i) (node3 j k l) m2
+
+----------------
+-- 4.4 Splitting
+----------------
+
+-- | /O(log(min(i,n-i)))/. Split a sequence at a point where the predicate
+-- on the accumulated measure of the prefix changes from 'False' to 'True'.
+--
+-- For predictable results, one should ensure that there is only one such
+-- point, i.e. that the predicate is /monotonic/.
+split ::  (Measured a) =>
+      Measure -> FingerTree a -> (FingerTree a, FingerTree a)
+split _ Empty  =  (Empty, Empty)
+split p xs
+  | (measure xs) >= p =  (l, x <| r)
+  | otherwise   =  (xs, Empty)
+  where
+    Split l x r = splitTree p 0 xs
+
+data Split t a = Split t a t
+
+splitTree :: (Measured a) =>
+    Measure -> Measure -> FingerTree a -> Split (FingerTree a) a
+splitTree _ _ Empty = illegal_argument "splitTree"
+splitTree _ _ (Single x) = Split Empty x Empty
+splitTree p i (Deep _ pr m sf)
+  | vpr > p     =  let  Split l x r     =  splitDigit p i pr
+                   in   Split (maybe Empty digitToTree l) x (deepL r m sf)
+  | vm > p      =  let  Split ml xs mr  =  splitTree p vpr m
+                        Split l x r     =  splitNode p (vpr + measure ml) xs
+                   in   Split (deepR pr  ml l) x (deepL r mr sf)
+  | otherwise   =  let  Split l x r     =  splitDigit p vm sf
+                   in   Split (deepR pr  m  l) x (maybe Empty digitToTree r)
+  where
+    vpr     =  i    +  measure pr
+    vm      =  vpr  +  measure m
+
+deepL :: (Measured a) =>
+    Maybe (Digit a) -> FingerTree (Node a) -> Digit a -> FingerTree a
+deepL Nothing m sf      =   rotL m sf
+deepL (Just pr) m sf    =   deep pr m sf
+
+deepR :: (Measured a) =>
+    Digit a -> FingerTree (Node a) -> Maybe (Digit a) -> FingerTree a
+deepR pr m Nothing      =   rotR pr m
+deepR pr m (Just sf)    =   deep pr m sf
+
+splitNode :: (Measured a) =>
+    Measure -> Measure -> Node a -> Split (Maybe (Digit a)) a
+splitNode p i (Node2 _ a b)
+  | va > p      = Split Nothing a (Just (One b))
+  | otherwise   = Split (Just (One a)) b Nothing
+  where
+    va      = i + measure a
+splitNode p i (Node3 _ a b c)
+  | va > p      = Split Nothing a (Just (Two b c))
+  | vab > p     = Split (Just (One a)) b (Just (One c))
+  | otherwise   = Split (Just (Two a b)) c Nothing
+  where
+    va      = i + measure a
+    vab     = va + measure b
+
+splitDigit :: (Measured a) =>
+    Measure  -> Measure -> Digit a -> Split (Maybe (Digit a)) a
+splitDigit _ i (One a) = i `seq` Split Nothing a Nothing
+splitDigit p i (Two a b)
+  | va > p      = Split Nothing a (Just (One b))
+  | otherwise   = Split (Just (One a)) b Nothing
+  where
+    va      = i + measure a
+splitDigit p i (Three a b c)
+  | va > p      = Split Nothing a (Just (Two b c))
+  | vab > p     = Split (Just (One a)) b (Just (One c))
+  | otherwise   = Split (Just (Two a b)) c Nothing
+  where
+    va      = i + measure a
+    vab     = va + measure b
+splitDigit p i (Four a b c d)
+  | va > p      = Split Nothing a (Just (Three b c d))
+  | vab > p     = Split (Just (One a)) b (Just (Two c d))
+  | vabc > p    = Split (Just (Two a b)) c (Just (One d))
+  | otherwise   = Split (Just (Three a b c)) d Nothing
+  where
+    va      = i + measure a
+    vab     = va + measure b
+    vabc    = vab + measure c
+
+------------------
+-- Transformations
+------------------
+
+illegal_argument :: String -> a
+illegal_argument name =
+    error $ "Logic error: " ++ name ++ " called with illegal argument"
+
+{- $example
+
+Particular abstract data types may be implemented by defining
+element types with suitable 'Measured' instances.
+
+(from section 4.5 of the paper)
+Simple sequences can be implemented using a 'Sum' monoid as a measure:
+
+> newtype Elem a = Elem { getElem :: a }
+>
+> instance Measured (Sum Int) (Elem a) where
+>     measure (Elem _) = Sum 1
+>
+> newtype Seq a = Seq (FingerTree (Sum Int) (Elem a))
+
+Then the measure of a subsequence is simply its length.
+This representation supports log-time extraction of subsequences:
+
+> take :: Int -> Seq a -> Seq a
+> take k (Seq xs) = Seq (takeUntil (> Sum k) xs)
+>
+> drop :: Int -> Seq a -> Seq a
+> drop k (Seq xs) = Seq (dropUntil (> Sum k) xs)
+
+The module @Data.Sequence@ is an optimized instantiation of this type.
+
+For further examples, see "Data.IntervalMap.FingerTree" and
+"Data.PriorityQueue.FingerTree".
+
+-}
+
+class ToBuilder a where
+  toBuilder :: a -> Builder
+
+instance ToBuilder S.ByteString where
+  toBuilder x = byteString x
+
+instance ToBuilder a => ToBuilder (FingerTree a) where
+  toBuilder ft =
+    case ft of
+      Empty -> mempty
+      Single x -> toBuilder x
+      Deep _ a b c -> toBuilder a <> toBuilder b <> toBuilder c
+
+instance ToBuilder a => ToBuilder (Node a) where
+  toBuilder n =
+    case n of
+      Node2 _ a b -> toBuilder a <> toBuilder b
+      Node3 _ a b c -> toBuilder a <> toBuilder b <> toBuilder c
+
+instance ToBuilder a => ToBuilder (Digit a) where
+  toBuilder d =
+    case d of
+      One a -> toBuilder a
+      Two a b -> toBuilder a <> toBuilder b
+      Three a b c -> toBuilder a <> toBuilder b <> toBuilder c
+      Four a b c e -> toBuilder a <> toBuilder b <> toBuilder c <> toBuilder e
+ 


### PR DESCRIPTION
This set of patches improves the performance of the library by 5-95%, depending on the benchmark; reasonable benchmarks see improvements more in the 25-50% range. These improvements arise from a couple key sources; most notably, including the `fingertree` library directly and de-abstracting it, and significant improvements to the Adler checksum computation.